### PR TITLE
Remove redundant debug print

### DIFF
--- a/LibResInfo-1.0.lua
+++ b/LibResInfo-1.0.lua
@@ -586,10 +586,8 @@ function eventFrame:UNIT_AURA(event, unit)
 	else
 		local reincarnation = UnitAura(unit, REINCARNATION, nil, "HARMFUL")
 		if reincarnation ~= hasReincarnation[guid] then
-			hasReincarnation[guid] = reincarnation
-			debug(2, nameFromGUID[guid], reincarnation and "active" or "inactive", REINCARNATION)
-
 			local endTime = GetTime() + RELEASE_PENDING_TIME
+			hasReincarnation[guid] = reincarnation
 			hasPending[guid] = endTime
 			debug(1, ">> ResPending", nameFromGUID[guid], REINCARNATION)
 			callbacks:Fire("LibResInfo_ResPending", unit, guid, endTime, true)


### PR DESCRIPTION
This debug print is not needed since the logic to detect Reincarnation is accurate.