### PR TITLE
Clear pending or reincarnation in scenarios where the alive logic fails

### DIFF
--- a/LibResInfo-1.0.lua
+++ b/LibResInfo-1.0.lua
@@ -639,6 +639,12 @@ function eventFrame:UNIT_FLAGS(event, unit)
 				debug(1, ">> UnitUpdate", nameFromGUID[guid], "(alive)")
 				callbacks:Fire("LibResInfo_UnitUpdate", unit, guid)
 			end
+		elseif hasPending[guid] or hasReincarnation[guid] then
+			hasPending[guid] = nil
+			hasReincarnation[guid] = nil
+
+			debug(1, ">> UnitUpdate", nameFromGUID[guid], "(alive)")
+			callbacks:Fire("LibResInfo_UnitUpdate", unit, guid)
 		end
 	elseif not isDead[guid] then
 		debug(2, nameFromGUID[guid], "is now dead")


### PR DESCRIPTION
In some scenarios `isDead` does not have record of a alive player (as it should), but `hasPending` and/or `hasReincarnation` does.
If that happens during UNIT_FLAGS, clear it out and fire an update.