### PR TITLE
Store the player unit regardless of group type

### DIFF
--- a/LibResInfo-1.0.lua
+++ b/LibResInfo-1.0.lua
@@ -322,13 +322,14 @@ function eventFrame:GROUP_ROSTER_UPDATE(event)
 	-- Update guid <==> unit mappings:
 	wipe(guidFromUnit)
 	wipe(unitFromGUID)
+
+	AddUnit("player")
 	if IsInRaid() then
 		for i = 1, GetNumGroupMembers() do
 			AddUnit("raid"..i)
 			AddUnit("raidpet"..i)
 		end
 	else
-		AddUnit("player")
 		AddUnit("pet")
 		if IsInGroup() then
 			for i = 1, GetNumGroupMembers() - 1 do


### PR DESCRIPTION
Alternatively, change [this line](https://github.com/phanx-wow/LibResInfo/blob/44458c6984fe61f9ecea020971ef567eb5e557a5/LibResInfo-1.0.lua#L580) to fetch the player GUID directly.

Handling `RESURRECT_REQUEST` requires the player GUID which is not stored when the group is a raid, so when the player dies and receives a resurrect it will spew errors.

Reported on wowinterface: http://www.wowinterface.com/forums/showpost.php?p=320891&postcount=145

```
LibResInfo-1.0-24.lua:580: table index is nil
LibResInfo-1.0-24.lua:580: in function `?'
\LibResInfo-1.0-24.lua:141: in function <...eGrid\Libs\LibResInfo-1.0\LibResInfo-1.0.lua:140>
```